### PR TITLE
Add a missing space and make the string more consistent...

### DIFF
--- a/install.php
+++ b/install.php
@@ -43,7 +43,7 @@ if (empty($check)) {
 	$sql = "ALTER TABLE `$db_name`.`$db_table_name` ADD INDEX `did` (`did` ASC)";
 	$result = $dbcdr->query($sql);
 	if(DB::IsError($result)) {
-		out(_("Unable to add index todid field in cdr table"));
+		out(_("Unable to add index to did field in the cdr table"));
 		freepbx_log(FPBX_LOG_ERROR, "Failed to add index to did field in the cdr table");
 	} else {
 		out(_("Adding index to did field in the cdr table"));


### PR DESCRIPTION
This adds a missing space and make the string more consistent with the neighboring ones by adding "the".

This was spotted while translating FreePBX.