### PR TITLE
change str_replace not working properly

### DIFF
--- a/page.cdr.php
+++ b/page.cdr.php
@@ -667,7 +667,7 @@ if (isset($cnum)) {
   $cnum_length = strlen($cnum);
   $cnum_type = substr($cnum, 0 ,strpos($cnum , 'cnum') -1);
   $cnum_remaining = substr($cnum, strpos($cnum , 'cnum'));
-  $src = str_replace('AND cnum', '', $cnum);
+  $src = substr($cnum, strpos($cnum , 'cnum') +4);
 
   $cnum = "$cnum_type ($cnum_remaining OR src $src)";
 }
@@ -676,7 +676,7 @@ if (isset($dst)) {
   $dst_length = strlen($dst);
   $dst_type = substr($dst, 0 ,strpos($dst , 'dst') -1);
   $dst_remaining = substr($dst, strpos($dst , 'dst'));
-  $dstchannel = str_replace('AND dst', '', $dst);
+  $dstchannel = substr($dst, strpos($dst , 'dst') +3);
 
   $dst = "$dst_type ($dst_remaining OR dstchannel $dstchannel)";
 }


### PR DESCRIPTION
I've trying retrieve multiple CallerID Numbers as filter without sucess,
Checked it using regexp "_200[67]" as CallerID Number without success. 
The $cnum variable showed as:
"AND (cnum RLIKE '^200[67]$' OR src AND cnum RLIKE '^200[67]$' )"
Note "AND cnum" still there.

Then, i've use "2006,2007" but only 2006 showed in results.
The $cnum variable showed as:
"AND (cnum LIKE '2006%' OR cnum LIKE '2007%' OR src LIKE '2006%' OR cnum LIKE '2007%')"
Take a look at last cnum 2007. This must be src but still as cnum.

With my proposition, this will not occur since we are getting string position.
Isn't clear the root cause of that but I think it's due to string manipulation before str_replace.