### PR TITLE
fix: order by clause should come first

### DIFF
--- a/ucp/Cdr.class.php
+++ b/ucp/Cdr.class.php
@@ -98,7 +98,7 @@ class Cdr extends Modules{
 		$displayvars = array(
 			'ext' => $id,
 			'activeList' => $view,
-			'calls' => $this->postProcessCalls($this->cdr->getCalls($id, 1, 'desc', 'date', '', $this->limit), $id),
+			'calls' => $this->postProcessCalls($this->cdr->getCalls($id, 1, 'date', 'desc', '', $this->limit), $id),
 			"showPlayback" => $this->_checkPlayback(),
 			"showDownload" => $this->_checkDownload(),
 			"extension" => $id,


### PR DESCRIPTION
In getWidgetDisplay, there is a call to cdr's getCalls function. In that function call the order of argument was wrong.  order by .i.e `date`  should come prior to order `desc`.

See https://github.com/FreePBX/cdr/blob/c1b32910966d715ebf689ee71371c19554286360/Cdr.class.php#L381