### PR TITLE
FREEI-1399- Transcription model heading should be same as v16 for other versions

### DIFF
--- a/assets/js/cdr.js
+++ b/assets/js/cdr.js
@@ -119,6 +119,9 @@ function openmodal(turl) {
     $("#addtionalcontent").html(result.html);
     $("#addtionalcontent").appendTo("body");
     $("#datamodal").modal('show');
+	$("#datamodal .modal-header").attr("style", function(i, style) {
+		return  'flex-direction: row !important;';
+	});
 }
 
 function closemodal() {


### PR DESCRIPTION
FREEI-1399- Transcription model heading should be same as v16 for other versions 
works fine in 16 and 15 .