### PR TITLE
Typo fix in Cdr.class.php

### DIFF
--- a/Cdr.class.php
+++ b/Cdr.class.php
@@ -55,7 +55,7 @@ class Cdr extends \FreePBX_Helpers implements \BMO {
 				// How about the default?
 				$defvalue = \FreePBX::Config()->get($default);
 				if ($defvalue) {
-					$cdr[$conf] = $defalue;
+					$cdr[$conf] = $defvalue;
 				} else {
 					// Well that's blank. Is it part of FreePBX::$conf? (That's the parsed output of /etc/freepbx.conf)
 					if (empty(\FreePBX::$conf[$default])) {


### PR DESCRIPTION
Maybe I'm wrong, but it looks like defvalue had a typo, which is why it was undefined.