### PR TITLE
FREEI-1521 Call Recording files are not able to play from CDR report

### DIFF
--- a/assets/js/cdr.js
+++ b/assets/js/cdr.js
@@ -42,7 +42,7 @@ function cdr_play(rowNum, uid) {
 			url: "ajax.php",
 			data: {module: "cdr", command: "gethtml5", uid: uid},
 			dataType: 'json',
-			timeout: 30000,
+			timeout: 60000,
 			success: function(data) {
 				var player = $("#jquery_jplayer_" + playerId);
 				if(data.status) {


### PR DESCRIPTION
	When huge number of records are there in the Timeout was causing
the issue