### PR TITLE
Backup & Restore module fails to preserve character encoding in CDRs

### DIFF
--- a/Backup.php
+++ b/Backup.php
@@ -14,7 +14,7 @@ class Backup Extends Base\BackupBase{
       $dumpOtherOptions[] = " --where='" . $query."'";
     }
 
-    $dumpOtherOptions[] = '--opt --compact --skip-lock-tables --skip-triggers --no-create-info';
+    $dumpOtherOptions[] = '--opt --skip-lock-tables --skip-triggers --no-create-info --default-character-set=utf8mb4';
     $dumpOtherOptions = implode(" ", $dumpOtherOptions);
 
     $fileObj = $this->dumpTableIntoFile('cdr','cdr', $dumpOtherOptions, true);


### PR DESCRIPTION
the mysqldump option '--compact' sets the option '--skip-set-charset' so no charset info is written to the sql-dump. This PR removes the --compact option and sets the default charset to utf8

Bugfix FreePBX/issue-tracker#503