### PR TITLE
Adding index to dstchannel

### DIFF
--- a/install.php
+++ b/install.php
@@ -83,6 +83,21 @@ if (empty($check)) {
 	}
 	out(_('Done'));
 }
+// add index to dstchannel
+$sql = "SHOW KEYS FROM `$db_name`.`$db_table_name` WHERE Key_name='dstchannel'";
+$check = $dbcdr->getOne($sql);
+if (empty($check)) {
+	outn(_('Adding index to dstchannel field...'));
+	$sql = "ALTER TABLE `$db_name`.`$db_table_name` ADD INDEX `dstchannel` (`dstchannel` ASC)";
+	$result = $dbcdr->query($sql);
+	if(DB::IsError($result)) {
+		out(_("Unable to add index to dstchannel field in the cdr table"));
+		freepbx_log(FPBX_LOG_ERROR, "Failed to add index to dstchannel field in the cdr table");
+	} else {
+		out(_("Adding index to dstchannel field in the cdr table"));
+	}
+	out(_('Done'));
+}
 
 // Remove this section in FreePBX 14
 $db_name = FreePBX::Config()->get('CDRDBNAME');


### PR DESCRIPTION
On systems with a lot of rows in the `cdr` table (e.g. 29 million rows, from over the last 12 months of operation only)...

If a user goes to the 'CDR Reports' module web page and does a simple query... for example...

- Enter a single call date from a couple of months ago (e.g. 21st February 2025)
- Enters in a destination phone number to search for

It'll generate this query in the backend...

```
SELECT `calldate`, `clid`, `did`, `src`, `dst`, `dcontext`, `channel`, `dstchannel`, `lastapp`, `lastdata`, `duration`, `billsec`, `disposition`, `amaflags`, `accountcode`, `uniqueid`, `userfield`, unix_timestamp(calldate) as `call_timestamp`, `recordingfile`, `cnum`, `cnam`, `outbound_cnum`, `outbound_cnam`, `dst_cnam`  FROM `asteriskcdrdb`.`cdr` WHERE calldate BETWEEN '2025-02-21 00:00:00' AND '2025-02-21 23:59:59' AND (dst  LIKE '07890123456%' OR dstchannel  LIKE '07890123456%') ORDER BY dst DESC LIMIT 100
```
Or more specifically this bit...
```
[...] (dst  LIKE '07890123456%' OR dstchannel  LIKE '07890123456%') [...] 
```

The trouble with that query... is whilst `dst` is one of 6 indexes that FreePBX sets up (at one point in its installation or another) along 5 other indexes of `calldate`, `accountcode`, `uniqueid`, `did`, and `recordingfile`...

The `OR` being used here... means it'll also search `dstchannel` which is **NOT** indexed!  This causes a full table search!  Which for a system as busy as this... can sometimes take hours (if it ever returns a result at all).

Once I added an index on `dstchannel`...

```
MariaDB [(none)]> ALTER TABLE `asteriskcdrdb`.`cdr` ADD INDEX `dstchannel` (`dstchannel` ASC);
Query OK, 28810723 rows affected (39 min 36.44 sec)
Records: 28810723  Duplicates: 0  Warnings: 0
```

Then bingo... search results are done in seconds.

Please merge this.