### PR TITLE
Fix Caller ID column rendering

### DIFF
--- a/page.cdr.php
+++ b/page.cdr.php
@@ -794,7 +794,7 @@ if ( $tot_calls_raw ) {
 		if ($row['cnam'] != '' || $row['cnum'] != '') {
 			cdr_formatCallerID($row['cnam'], $row['cnum'], $row['channel']);
 		} else {
-			cdr_formatSrc(str_replace('"" ','',(string) $row['clid']), str_replace('"" ','',(string) $row['clid']));
+			cdr_formatSrc(str_replace('"" ','',(string) $row['clid']));
 		}
 		cdr_formatCallerID($row['outbound_cnam'], $row['outbound_cnum'], $row['dstchannel']);
 		cdr_formatDID($row['did']);
@@ -1124,12 +1124,12 @@ function cdr_formatChannel($channel) {
 	echo '<td title="' . _("Channel") . ": " . $channel . '">' . $chan_type[0] . "</td>";
 }
 
-function cdr_formatSrc($src, $clid) {
-	if (empty($src)) {
+function cdr_formatSrc($clid) {
+	if (empty($clid)) {
 		echo "<td class=\"record_col\">UNKNOWN</td>";
 	} else {
 		$clid = htmlspecialchars((string) $clid);
-		echo '<td title="' . _("CallerID") . ": " . $clid . '">' . $src . "</td>";
+		echo '<td title="' . _("CallerID") . ": " . $clid . '">' . $clid . "</td>";
 	}
 }
 


### PR DESCRIPTION
This PR refactors the page.cdr.php file by removing redundant parameters in cdr_formatSrc function and addressing an issue where HTML rendering could crash due to unescaped content.